### PR TITLE
Remove dead donation link

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -1,6 +1,6 @@
 title: Molly
 baseurl: '/' # Website URL
-copyright: '© {year} Molly.im<br><br>Site made by <a href="https://benarmstead.co.uk">Ben Armstead</a> for the Molly project.<br>https://benarmstead.co.uk/#donate'
+copyright: '© {year} Molly.im<br><br>Site made by <a href="https://benarmstead.co.uk">Ben Armstead</a> for the Molly project.'
 
 defaultContentLanguage: en
 hasCJKLanguage: false


### PR DESCRIPTION
The link is not yet dead, but I intend to soon change my website, in which this link will be dead. Plus there isn't really a need for 2 links to my website.