### PR TITLE
Reference github's comparison table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -86,7 +86,7 @@
         </svg>
         <span class="tit">Fully FOSS</span>
         <span class="subtit">
-                    Contains no proprietary blobs, unlike Signal
+                    Contains <a href="https://github.com/mollyim/mollyim-android#feature-comparison">no proprietary blobs</a>, unlike Signal
                 </span>
       </div>
     </div>


### PR DESCRIPTION
Requested on [matrix](https://matrix.to/#/!tSLUCcxsHtacpRumvx:matrix.org/$bUmu8EPsxO3Wcn0aBUTBiGZ0pyAm6urIDJyh5gWM8SY), some people were wondering what the proprietary blobs were.